### PR TITLE
Make it compilable with GHC HEAD (v7.9)

### DIFF
--- a/src/Physics/ForceLayout.hs
+++ b/src/Physics/ForceLayout.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
See ghc bug #8883 and related discussion http://www.haskell.org/pipermail/ghc-devs/2014-June/005180.html

This is the error that GHC emits:

```
src/Physics/ForceLayout.hs:148:9:
    Illegal equational constraint Scalar b ~ Scalar v
    (Use GADTs or TypeFamilies to permit this)
    In the context: (VectorSpace b, Scalar b ~ Scalar v)
    While checking the inferred type for ?stepVel?
    In an equation for ?particleStep?:
        particleStep d
          = stepPos . stepVel
          where
              stepVel p = vel .~ (d *^ (p ^. vel ^+^ p ^. force)) $ p
              stepPos p = pos %~ (.+^ p ^. vel) $ p
```

Btw. as of today this message will become explained even better.
