### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/force-layout.cabal
+++ b/force-layout.cabal
@@ -21,7 +21,7 @@ source-repository head
 library
   exposed-modules:     Physics.ForceLayout
   build-depends:       base >= 4.2 && < 4.8,
-                       linear >= 1.10 && < 1.12,
+                       linear >= 1.10 && < 1.11,
                        lens >= 3.0 && < 4.6,
                        containers >=0.4 && < 0.6,
                        data-default-class >= 0.0.1 && < 0.1


### PR DESCRIPTION
Allow `force-layout` to use the latest version of `lens` (4.5).
