### PR TITLE
Relax base bound for GHC 8.2

### DIFF
--- a/force-layout.cabal
+++ b/force-layout.cabal
@@ -21,7 +21,7 @@ source-repository head
 
 library
   exposed-modules:     Physics.ForceLayout
-  build-depends:       base >= 4.2 && < 4.10,
+  build-depends:       base >= 4.2 && < 4.11,
                        linear >= 1.10 && < 1.21,
                        lens >= 3.0 && < 4.16,
                        containers >=0.4 && < 0.6,


### PR DESCRIPTION
GHC 8.2 will ship with base-4.10